### PR TITLE
packages: snort3, snort3-extra version 3.1.58.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ALPINE_VERSION := 3.17.2
 CONTAINERFILE=Containerfile
 
 # Define the docker image name
-IMAGE_NAME := $(ARCH)/krakatoa 
+IMAGE_NAME := $(ARCH)/krakatoa
 
 .PHONY: build
 
@@ -15,3 +15,6 @@ build:
 		-t $(IMAGE_NAME) \
 		-f $(CONTAINERFILE) \
 		.
+
+run:
+	docker run --rm -ti $(IMAGE_NAME) sh

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Several dependencies to build a complete version of Snort 3 are not part officia
 
  * [hwloc 2.9.0](https://www-lb.open-mpi.org/software/hwloc/v2.9/)
  * [jemalloc 5.3.0](https://github.com/jemalloc/jemalloc/releases/tag/5.3.0/)
- * [Vectorscan 5.4.8](https://github.com/VectorCamp/vectorscan/releases/tag/vectorscan/5.4.8)
+ * [Vectorscan 5.4.9](https://github.com/VectorCamp/vectorscan/releases/tag/vectorscan/5.4.9)
  * [LibDAQ 3.0.11](https://github.com/snort3/libdaq/releases/tag/v3.0.11)
- * [Snort3 3.1.57.0](https://github.com/snort3/snort3/releases/tag/3.1.57.0)
- * [Snort3 Extra 3.1.57.0](https://github.com/snort3/snort3_extra/releases/tag/3.1.57.0)
+ * [Snort3 3.1.58.0](https://github.com/snort3/snort3/releases/tag/3.1.58.0)
+ * [Snort3 Extra 3.1.58.0](https://github.com/snort3/snort3_extra/releases/tag/3.1.58.0)
  * [AbcIP 2.4.1](https://github.com/crc181/abcip)[^1]
  * [Lightspd Manifest 0.1.0](https://github.com/wtfbbqhax/lightspd-manifest)
 

--- a/packages/hyperscan/APKBUILD
+++ b/packages/hyperscan/APKBUILD
@@ -3,7 +3,7 @@
 # Based on original by Duncan Bellamy <dunk@denkimushi.com>
 # Vectorscan, a hyperscan alternative that works on aarch64.
 pkgname=hyperscan
-pkgver=5.4.8
+pkgver=5.4.9
 pkgrel=0
 pkgdesc="A fork of Intel's Hyperscan, modified to run on more platforms."
 url="https://github.com/VectorCamp/vectorscan"
@@ -71,5 +71,5 @@ tools() {
 }
 
 sha512sums="
-336f10a9bd5f2531830917ffeb78c0dad86cadde0fd4a409e1f064f1311191870804264a52d3d90c5d897465041eb256196e1c5511766da98b3c8d832ae33edc  vectorscan-5.4.8.tar.gz
+2a482eaf60a51efb6f1235eb0c2614e791b3533d346b5e42c6b1362afa12f3ebf2ae2d32c125dfdb665bae55cdbe8f099f8466cda131ef6ce1dd6ece0a3f1458  vectorscan-5.4.9.tar.gz
 "

--- a/packages/snort3-extra/APKBUILD
+++ b/packages/snort3-extra/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Victor Roemer <victor@badsec.org>
 # Maintainer: Victor Roemer <victor@badsec.org>
 pkgname="snort3-extra"
-pkgver="3.1.57.0"
+pkgver="3.1.58.0"
 pkgrel=0
 pkgdesc="Snort3 Extra Stuff"
 url="https://github.com/snort3/snort3_extra"
@@ -31,5 +31,5 @@ package() {
 }
 
 sha512sums="
-64f371e027804bd5e50b3b7afb45ffcb9e61af58aac50bb9e56733bb8b8a2172cefb8aedf059c5b7d8bedf2bc2941221a9e88901455130dc1d7977f26013d052  snort3-extra-3.1.57.0.tar.gz
+769c78152d9efb6fe0075b2f828ae140ab1de0d35fc22c0bbc8924856cd7aaf90393c67087c9ba56bbdede7d07bcce224b1af36d2bc2f6e35aa16bdad8b3a643  snort3-extra-3.1.58.0.tar.gz
 "

--- a/packages/snort3/APKBUILD
+++ b/packages/snort3/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Victor Roemer <victor@badsec.org>
 # Maintainer: Victor Roemer <victor@badsec.org>
 pkgname=snort3
-pkgver=3.1.57.0
+pkgver=3.1.58.0
 pkgrel=1
 pkgdesc="Snort3 Intrusion Prevention System"
 url="www.snort.org"
@@ -89,5 +89,5 @@ utils() {
 }
 
 sha512sums="
-0a251f63505ff20331b6f66d9de57e661a166f67fc8df21ca5b4ec6a180f6bc83c9a23fbb3ba637d4cc330527ca8a9427aa6147983f521e711ed04808d7010c4  snort3-3.1.57.0.tar.gz
+e36c2f38647d527b98752b082d7bac020c826a29bc0f171f099b98bea9ac79659a2c3e4c7d8bcf7304be3270011f7a29ead6df5e9aece33c3bbf7b9c087327eb  snort3-3.1.58.0.tar.gz
 "


### PR DESCRIPTION
Update snort3 and snort3-extra packages to version 3.1.58.0.