### PR TITLE
Makefile: Add aarch64 build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,22 @@
 # Define variables for build args
-ARCH := $(or $(ARCH),amd64)
 ALPINE_VERSION := 3.17.3
-CONTAINERFILE=Containerfile
+CONTAINERFILE=Containerfile.working
+
+# User may specify the architecture to build else build for the host
+ARCH ?= $(shell uname -m)
+ifeq ($(filter $(ARCH), amd64 arm64),)
+    $(error Unsupported architecture: $(ARCH))
+endif
+ARCH := $(if $(filter $(ARCH), x86_64),amd64,arm64v8)
 
 # Define the docker image name
-IMAGE_NAME := $(ARCH)/krakatoa
+IMAGE_NAME := $(ARCH)/krakatoa:working
 
-.PHONY: build
+.PHONY: build run
 
 build:
 	docker build \
+		--no-cache \
 		--build-arg ARCH=$(ARCH) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		-t $(IMAGE_NAME) \


### PR DESCRIPTION
This commit adds support for the aarch64 build targets, and allows the user to specify the architecture to build. If no architecture is specified then build a container compatible with the for the host machine.

CHANGES

Makefile:

 * Update Makefile to support arm64v8 and amd64 build targets.

   Optionally let user specify the ARCH to support cross compiling environments.

TESTING

 * Verified building and running arm64v8 image on M1 Mac.

 * Verified ARCH can be assigned by user