### PR TITLE
packages: tcpreplay version 4.4.3

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -28,8 +28,9 @@ RUN APKBUILD="$PACKAGE_DIR/hwloc/APKBUILD" abuild -r
 RUN APKBUILD="$PACKAGE_DIR/libdaq/APKBUILD" abuild -r
 RUN APKBUILD="$PACKAGE_DIR/snort3/APKBUILD" abuild -r
 RUN APKBUILD="$PACKAGE_DIR/snort3-extra/APKBUILD" abuild -r
-RUN APKBUILD="$PACKAGE_DIR/abcip/APKBUILD" abuild -r
 RUN APKBUILD="$PACKAGE_DIR/lightspd-manifest/APKBUILD" abuild -r
+RUN APKBUILD="$PACKAGE_DIR/abcip/APKBUILD" abuild -r
+RUN APKBUILD="$PACKAGE_DIR/tcpreplay/APKBUILD" abuild -r
 
 # cleanup
 RUN unset PACKAGE_DIR

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Several dependencies to build a complete version of Snort 3 are not part officia
  * [LibDAQ 3.0.11](https://github.com/snort3/libdaq/releases/tag/v3.0.11)
  * [Snort3 3.1.58.0](https://github.com/snort3/snort3/releases/tag/3.1.58.0)
  * [Snort3 Extra 3.1.58.0](https://github.com/snort3/snort3_extra/releases/tag/3.1.58.0)
- * [AbcIP 2.4.1](https://github.com/crc181/abcip)[^1]
  * [Lightspd Manifest 0.1.0](https://github.com/wtfbbqhax/lightspd-manifest)
+ * [AbcIP 2.4.1](https://github.com/crc181/abcip)[^1]
+ * [Tcpreplay 4.4.3](https://github.com/appneta/tcpreplay/releases/tag/v4.4.3)
 
 [^1]: AbcIP version 2.4.1 is not a real tagged build, our package builds the HEAD of master. -wtfbbqhax
 

--- a/packages/tcpreplay/APKBUILD
+++ b/packages/tcpreplay/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Victor Roemer <victor@badsec.org>
+# Maintainer: Victor Roemer <victor@badsec.org>
+pkgname=tcpreplay
+pkgver=4.4.3
+pkgrel=0
+pkgdesc="Tcpreplay is a suite of free Open Source utilities for editing and replaying previously captured network traffic."
+url="https://tcpreplay.appneta.com"
+arch="all"
+license="GPL-3.0"
+options='!fhs !check'
+giturl="https://github.com/appneta/tcpreplay.git"
+depends="libpcap"
+makedepends="git libpcap-dev autoconf automake libtool"
+source="https://github.com/appneta/tcpreplay/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
+
+build() {
+	./configure
+	make -C "$builddir"
+}
+
+package() {
+	make -C "$builddir" DESTDIR="$pkgdir" install
+}
+
+sha512sums="
+f69137ef41d16f4acda4190245f73f0b3db950783e5a6fc3374c27eae80c8bf096f5392c18c1b33b90bc32380625c5b5f149f7ec1c50b971ddd761279abffe68  tcpreplay-4.4.3.tar.gz
+"


### PR DESCRIPTION
This commit adds the popular network traffic replay tool tcpreplay.

CHANGES

packages/tcpreplay/APKBUILD:

 * Packaging for tcpreplay version 4.4.3

README.md:

 * Update software packaging references in README.