### PR TITLE
github/actions: Add arm64v8 build target

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,11 +8,36 @@ on:
 
 jobs:
 
-  build:
+  arm64v8:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-    - name: Build Krakatoa and Packages
-      run: docker build . --build-arg ARCH=amd64 --build-arg ALPINE_VERSION=3.17.2 --file Containerfile --tag krakatoa:$(date +%s)
+    - uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+    - uses: docker/build-push-action@v4
+      with:
+        push: false
+        build-args: |-
+          ARCH=arm64v8
+          ALPINE_VERSION=3.18.2
+        file: Containerfile
+        tags: amd64/krakatoa:latest
+
+  amd64:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: docker/build-push-action@v4
+      with:
+        push: false
+        build-args: |-
+          ARCH=amd64
+          ALPINE_VERSION=3.18.2
+        file: Containerfile
+        tags: amd64/krakatoa:latest
+

--- a/Containerfile
+++ b/Containerfile
@@ -22,6 +22,7 @@ USER build
 WORKDIR /home/build
 
 ENV PACKAGE_DIR=/home/build/packages
+
 RUN APKBUILD="$PACKAGE_DIR/jemalloc/APKBUILD" abuild -r
 RUN APKBUILD="$PACKAGE_DIR/hyperscan/APKBUILD" abuild -r
 RUN APKBUILD="$PACKAGE_DIR/hwloc/APKBUILD" abuild -r
@@ -31,5 +32,5 @@ RUN APKBUILD="$PACKAGE_DIR/snort3_extra/APKBUILD" abuild -r
 RUN APKBUILD="$PACKAGE_DIR/abcip/APKBUILD" abuild -r
 RUN APKBUILD="$PACKAGE_DIR/lightspd-manifest/APKBUILD" abuild -r
 
-# cleanup
+## cleanup
 RUN unset PACKAGE_DIR

--- a/packages/jemalloc/APKBUILD
+++ b/packages/jemalloc/APKBUILD
@@ -18,7 +18,7 @@ options="!check"
 
 build() {
 	echo "$pkgver" > VERSION
-	./configure --prefix=/usr --enable-silent-rules
+	./configure --prefix=/usr
 	make
 }
 


### PR DESCRIPTION
This PR adds an additional job for arm64v8 target architecture using the [docker/setup-qemu action][qemu].

This PR also changes transitions to the [docker/build-push action][build-push], dropping the run command.

Some outstanding tasks:
 * Test image/s
 * Publish image/s to a registry

[qemu]: <https://github.com/docker/setup-qemu-action>
[build-push]: <https://github.com/docker/build-push-action>