### PR TITLE
github/actions: Disable arm64v8 build target

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,7 @@ on:
 jobs:
 
   arm64v8:
+    if: false # disable arm64v8 cross compile for now
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This commit disables the arm64v8 cross compile build.

The arm64v8 build target is unforgivably slow taking 5+ hours on average while not producing a justifiable value.  The most recent Snort version update PR failed due to the arm64v8 build timing out, which is unacceptable.