### PR TITLE
Makefile: Update to Alpine Linux version 3.21.2

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
-ARG ALPINE_VERSION
-ARG ARCH
+ARG ALPINE_VERSION=latest
+ARG ARCH=arm64v8
 
-FROM $ARCH/alpine:$ALPINE_VERSION as alpine_package_builder
+FROM $ARCH/alpine:$ALPINE_VERSION AS alpine_package_builder
 RUN apk update
 RUN apk add abuild atools
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Define variables for build args
-ALPINE_VERSION := 3.20.2
+ALPINE_VERSION := 3.21.2
 CONTAINERFILE=Containerfile
 
 # User may specify the architecture to build else build for the host

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![Krakatoa-Image Logo](doc/silhouette-of-krakatoa-volcano-eruption.svg)
 
-**FROM [Alpine Linux 3.20.2](https://www.alpinelinux.org/posts/Alpine-3.20.2-released.html)**
+**FROM [Alpine Linux 3.21.2](https://www.alpinelinux.org/posts/Alpine-3.18.11-3.19.6-3.20.5-3.21.2-released.html)**
 
 This repository serves as a reference for building a custom Alpine container images based on the Alpine Linux. We make use of the Alpine Packaging tools `abuild` and `apk` to build a package repository local to the image itself. The local package repo builds package and subpackage targets from the software listed below.
 


### PR DESCRIPTION
This commit updates the Alpine Linux base version from version 3.20.0 to 3.21.2. This commit also contains supplemental updates to Containerfile to assign valid default values to ARGs to prevent errors when used in FROM instruction.

CHANGES

Containerfile:

 * Assign valid default values to the ALPINE_VERSION and ARCH ARGS.

Makefile,
README.md:

 * Update to Alpine Linux version 3.21.2.