### PR TITLE
packages/snort3: Update to Snort version 3.6.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build:
 
 .PHONY: start
 start:
-	docker run --rm -v$(PWD)/mount:/volumes -td $(IMAGE_NAME)
+	docker run --rm -v$(PWD)/volumes:/volumes -td $(IMAGE_NAME)
 
 .PHONY: stop
 stop:

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This repository serves as a reference for building a custom Alpine container ima
 ### Packaged Software
 Several dependencies to build a complete version of Snort 3 are not part officially supported by Alpine Linux or what does exist did not meet my expectations so they've been pulled directly. Additionally, the Snort3, Snort3 Extra and LibDAQ packages were solely produced for **Krakatoa**.
 
- * [Snort3 3.3.2.0](https://github.com/snort3/snort3/releases/tag/3.3.2.0)
+ * [Snort3 3.6.2.0](https://github.com/snort3/snort3/releases/tag/3.6.2.0)
  * [Snort3 Extra 3.3.2.0](https://github.com/snort3/snort3_extra/releases/tag/3.3.2.0)
  * [hwloc 2.9.1](https://www-lb.open-mpi.org/software/hwloc/v2.9/)
  * [jemalloc 5.3.0](https://github.com/jemalloc/jemalloc/releases/tag/5.3.0/)
  * [Vectorscan 5.4.11](https://github.com/VectorCamp/vectorscan/releases/tag/vectorscan/5.4.11)
- * [LibDAQ 3.0.16](https://github.com/snort3/libdaq/releases/tag/v3.0.16)
+ * [LibDAQ 3.0.18](https://github.com/snort3/libdaq/releases/tag/v3.0.18)
  * [AbcIP 2.4.1](https://github.com/crc181/abcip)[^1]
  * [Lightspd Manifest 0.1.0](https://github.com/wtfbbqhax/lightspd-manifest)
 

--- a/packages/libdaq/APKBUILD
+++ b/packages/libdaq/APKBUILD
@@ -3,7 +3,7 @@
 #
 # TODO Make sure module debug symbols do not get packaged into the libdaq-dbg
 pkgname=libdaq
-pkgver=3.0.16
+pkgver=3.0.18
 pkgrel=0
 pkgdesc="Snort3 DAQ"
 url="www.snort.org"
@@ -191,7 +191,7 @@ gwlb_module_static() {
 }
 
 sha512sums="
-41d215ec795524e0ab505eba5e90e92d6efb8d17368e63b5a9de619c5d312316205cf8785c9cf6e384536c92e59f21b93d7a5fe86f04a5708a2d06c09088a4ba  libdaq-3.0.16.tar.gz
+0d2d2510b1e4ad4ced41e272c67d1d248a614122dc4d91617067c14b4c2ec21d1cdca947acf9c2c1dfcfd4a2b029fbdfd257b61029b4fe8458e2fc39c6bbe830  libdaq-3.0.18.tar.gz
 "
 
 # FIXME Breakout dbg symbols for each daq module into separate packages.

--- a/packages/snort3/APKBUILD
+++ b/packages/snort3/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Victor Roemer <victor@badsec.org>
 # Maintainer: Victor Roemer <victor@badsec.org>
 pkgname=snort3
-pkgver=3.3.2.0
+pkgver=3.6.2.0
 pkgrel=0
 pkgdesc="Snort3 Intrusion Prevention System"
 url="www.snort.org"
@@ -15,7 +15,7 @@ checkdepends="cppcheck cpputest"
 depends="libdnet
 	xz-libs
 	libuuid
-	pcre
+	pcre2
 	libtirpc
 	libressl
 	libdaq
@@ -33,7 +33,7 @@ makedepends="cmake
 	libressl-dev
 	libtirpc-dev
 	libuuid
-	pcre-dev
+	pcre2-dev
 	xz-dev
 	zlib-dev
 	libdaq
@@ -89,5 +89,5 @@ utils() {
 }
 
 sha512sums="
-26166f74aa537f4108b9fc53996a89e31b6d44ee03831526e0e3cd77b180bacb7f6ee2451b96ee4eace90026529f05f7b6b6e189e4e25499e849443a13b745ee  snort3-3.3.2.0.tar.gz
+fceea17239e923ca20817bddb2e87504f84bbb816f8d3585c7ae3eb46d98cc157a651f41a94f4c676d37032495215269a1d9d476ec1fe06f5bef57c45aff7b1d  snort3-3.6.2.0.tar.gz
 "


### PR DESCRIPTION
packages/snort3: Update to Snort version 3.6.2.0
packages/libdaq: Update to libdaq version 3.0.18

Update Snort to version 3.6.2.0.

> [!IMPORTANT]
> Appears I will need to also update libpcre to libpcre2 per the Release notes:
> https://github.com/snort3/snort3/releases/tag/3.6.2.0